### PR TITLE
feat: add JSON/YAML go-to-definition for TS members

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -2047,6 +2047,7 @@
       "json-type-checker": {
         "dependencies": [
           "jsr:@cliffy/command@1.0.0-rc.7",
+          "jsr:@std/assert@1",
           "jsr:@std/fs@1",
           "jsr:@std/path@1",
           "npm:jsonc-parser@3",

--- a/json-type-checker/deno.json
+++ b/json-type-checker/deno.json
@@ -4,6 +4,7 @@
   "license": "MIT",
   "exports": {
     "./check": "./src/check.ts",
+    "./definition": "./src/definition.ts",
     "./document": "./src/document.ts",
     "./json": "./src/json.ts",
     "./rough-json": "./src/rough-json.ts",
@@ -12,6 +13,7 @@
   },
   "imports": {
     "@cliffy/command": "jsr:@cliffy/command@1.0.0-rc.7",
+    "@std/assert": "jsr:@std/assert@1",
     "@std/fs": "jsr:@std/fs@1",
     "@std/path": "jsr:@std/path@1",
     "jsonc-parser": "npm:jsonc-parser@3",

--- a/json-type-checker/src/definition.test.ts
+++ b/json-type-checker/src/definition.test.ts
@@ -1,0 +1,119 @@
+import { assert, assertEquals } from "@std/assert";
+import { join } from "@std/path";
+import { findDefinition } from "./definition.ts";
+
+Deno.test("findDefinition resolves top-level property members", async () => {
+  const tempDir = await Deno.makeTempDir();
+
+  try {
+    const typesPath = join(tempDir, "types.ts");
+    const jsonPath = join(tempDir, "config.json");
+    await Deno.writeTextFile(
+      typesPath,
+      `export interface User {
+  name: string;
+  age: number;
+}
+`,
+    );
+    await Deno.writeTextFile(jsonPath, "{}");
+
+    const target = findDefinition(["name"], "./types.ts#User", {
+      baseFilePath: jsonPath,
+    });
+
+    assert(target);
+    if (!target) throw new Error("expected definition target");
+    assertEquals(target.filePath, typesPath.replaceAll("\\", "/"));
+
+    const source = await Deno.readTextFile(typesPath);
+    assertEquals(
+      source.slice(
+        target.targetSelectionSpan.start,
+        target.targetSelectionSpan.end,
+      ),
+      "name",
+    );
+  } finally {
+    await Deno.remove(tempDir, { recursive: true });
+  }
+});
+
+Deno.test("findDefinition resolves $type to the root type declaration", async () => {
+  const tempDir = await Deno.makeTempDir();
+
+  try {
+    const typesPath = join(tempDir, "types.ts");
+    const jsonPath = join(tempDir, "config.json");
+    await Deno.writeTextFile(
+      typesPath,
+      `export interface User {
+  name: string;
+  age: number;
+}
+`,
+    );
+    await Deno.writeTextFile(jsonPath, "{}");
+
+    const target = findDefinition(["$type"], "./types.ts#User", {
+      baseFilePath: jsonPath,
+    });
+
+    assert(target);
+    if (!target) throw new Error("expected definition target");
+
+    const source = await Deno.readTextFile(typesPath);
+    assertEquals(
+      source.slice(
+        target.targetSelectionSpan.start,
+        target.targetSelectionSpan.end,
+      ),
+      "User",
+    );
+  } finally {
+    await Deno.remove(tempDir, { recursive: true });
+  }
+});
+
+Deno.test("findDefinition resolves nested object members through array paths", async () => {
+  const tempDir = await Deno.makeTempDir();
+
+  try {
+    const typesPath = join(tempDir, "types.ts");
+    const jsonPath = join(tempDir, "config.json");
+    await Deno.writeTextFile(
+      typesPath,
+      `export interface Address {
+  street: string;
+}
+
+export interface User {
+  addresses: Address[];
+}
+`,
+    );
+    await Deno.writeTextFile(jsonPath, "{}");
+
+    const target = findDefinition(
+      ["addresses", 0, "street"],
+      "./types.ts#User",
+      {
+        baseFilePath: jsonPath,
+      },
+    );
+
+    assert(target);
+    if (!target) throw new Error("expected definition target");
+
+    const source = await Deno.readTextFile(typesPath);
+    assertEquals(
+      source.slice(
+        target.targetSelectionSpan.start,
+        target.targetSelectionSpan.end,
+      ),
+      "street",
+    );
+  } finally {
+    await Deno.remove(tempDir, { recursive: true });
+  }
+});

--- a/json-type-checker/src/definition.test.ts
+++ b/json-type-checker/src/definition.test.ts
@@ -75,6 +75,35 @@ Deno.test("findDefinition resolves $type to the root type declaration", async ()
   }
 });
 
+Deno.test("findDefinition returns null for unresolved nested path segments", async () => {
+  const tempDir = await Deno.makeTempDir();
+
+  try {
+    const typesPath = join(tempDir, "types.ts");
+    const jsonPath = join(tempDir, "config.json");
+    await Deno.writeTextFile(
+      typesPath,
+      `export interface Profile {
+  name: string;
+}
+
+export interface User {
+  profile: Profile;
+}
+`,
+    );
+    await Deno.writeTextFile(jsonPath, "{}");
+
+    const target = findDefinition(["profile", "nickname"], "./types.ts#User", {
+      baseFilePath: jsonPath,
+    });
+
+    assertEquals(target, null);
+  } finally {
+    await Deno.remove(tempDir, { recursive: true });
+  }
+});
+
 Deno.test("findDefinition resolves nested object members through array paths", async () => {
   const tempDir = await Deno.makeTempDir();
 

--- a/json-type-checker/src/definition.ts
+++ b/json-type-checker/src/definition.ts
@@ -1,0 +1,439 @@
+import { dirname, join, relative } from "@std/path/posix";
+import ts from "typescript";
+import type { CheckOptions } from "./check.ts";
+import type { Path, Span } from "./type.ts";
+
+const ROOT_MODULE_ALIAS = "__jtc_module";
+const ROOT_TYPE_ALIAS = "__JtcRootType";
+
+export interface TypeDefinition {
+  filePath: string;
+  targetSpan: Span;
+  targetSelectionSpan: Span;
+}
+
+export function findDefinition(
+  path: Path,
+  typePath: string,
+  baseFilePathOrOptions?: string | CheckOptions,
+): TypeDefinition | null {
+  const options = toCheckOptions(baseFilePathOrOptions);
+  const baseFilePath = options.baseFilePath;
+  const { modulePath, typeName } = parseTypePath(typePath);
+  const entryFile = resolveVirtualEntryPath(baseFilePath);
+  const entryDir = dirname(entryFile);
+  const moduleSpecifier = resolveModuleSpecifier(modulePath, entryDir);
+  const sourceText = buildDefinitionSource(moduleSpecifier, typeName);
+  const compilerOptions = resolveCompilerOptions(options);
+  const fs = options.fs;
+  const preferFsOnly = options.preferFileSystemOnly === true && fs != null;
+
+  const baseHost = ts.createCompilerHost(compilerOptions, true);
+  const readSource = (fileName: string): string | undefined => {
+    if (fileName === entryFile) return sourceText;
+    const text = fs?.readFile(fileName);
+    if (text != null) return text;
+    if (preferFsOnly) return undefined;
+    return baseHost.readFile(fileName);
+  };
+
+  const host: ts.CompilerHost = {
+    ...baseHost,
+    fileExists(fileName) {
+      if (fileName === entryFile) return true;
+      if (fs?.fileExists(fileName)) return true;
+      if (preferFsOnly) return false;
+      return baseHost.fileExists(fileName);
+    },
+    readFile(fileName) {
+      return readSource(fileName);
+    },
+    getSourceFile(fileName, languageVersion) {
+      const text = readSource(fileName);
+      if (text == null) return undefined;
+      return ts.createSourceFile(fileName, text, languageVersion, true);
+    },
+  };
+
+  const program = ts.createProgram([entryFile], compilerOptions, host);
+  const sourceFile = program.getSourceFile(entryFile);
+  if (!sourceFile) return null;
+
+  const checker = program.getTypeChecker();
+  const valueDeclaration = findValueDeclarationInFile(sourceFile);
+  const rootTypeNode = valueDeclaration?.type;
+  if (!rootTypeNode) return null;
+
+  if (path.length === 1 && path[0] === "$type") {
+    return findRootTypeDefinition(sourceFile, checker);
+  }
+
+  let currentTypes = dedupeTypes([checker.getTypeFromTypeNode(rootTypeNode)]);
+  let lastSymbols: ts.Symbol[] = [];
+
+  for (const item of path) {
+    if (typeof item === "number") {
+      const nextTypes = dedupeTypes(
+        currentTypes.flatMap((type) =>
+          resolveIndexedTypes(checker, type, item)
+        ),
+      );
+      if (nextTypes.length === 0) {
+        return symbolsToDefinition(lastSymbols);
+      }
+      currentTypes = nextTypes;
+      continue;
+    }
+
+    const matches = currentTypes.flatMap((type) =>
+      resolvePropertyMatches(checker, type, item)
+    );
+    if (matches.length === 0) {
+      return symbolsToDefinition(lastSymbols);
+    }
+
+    lastSymbols = dedupeSymbols(matches.map((item) => item.symbol));
+    currentTypes = dedupeTypes(matches.map((item) => item.type));
+  }
+
+  return symbolsToDefinition(lastSymbols);
+}
+
+function toCheckOptions(
+  baseFilePathOrOptions?: string | CheckOptions,
+): CheckOptions {
+  if (typeof baseFilePathOrOptions === "string") {
+    return { baseFilePath: baseFilePathOrOptions };
+  }
+  return baseFilePathOrOptions ?? {};
+}
+
+function parseTypePath(
+  typePath: string,
+): { modulePath: string; typeName: string } {
+  const hashIndex = typePath.lastIndexOf("#");
+  if (hashIndex <= 0 || hashIndex >= typePath.length - 1) {
+    throw new Error(
+      "Invalid typePath. Expected format: ./path/to/file.ts#TypeName",
+    );
+  }
+  return {
+    modulePath: typePath.slice(0, hashIndex),
+    typeName: typePath.slice(hashIndex + 1),
+  };
+}
+
+function resolveVirtualEntryPath(baseFilePath?: string): string {
+  const normalizedBasePath = baseFilePath && baseFilePath.length > 0
+    ? toPosixPath(baseFilePath)
+    : undefined;
+  const baseDir = normalizedBasePath ? dirname(normalizedBasePath) : Deno.cwd();
+  return toPosixPath(join(baseDir, "__jtc_definition__.ts"));
+}
+
+function resolveModuleSpecifier(modulePath: string, entryDir: string): string {
+  const normalized = toPosixPath(modulePath);
+
+  if (isRelativeSpecifier(normalized)) {
+    return normalized;
+  }
+
+  if (isAbsolutePath(normalized)) {
+    const rel = toPosixPath(relative(entryDir, normalized));
+    return ensureRelativeSpecifier(rel);
+  }
+
+  return modulePath;
+}
+
+function isAbsolutePath(path: string): boolean {
+  if (path.startsWith("/")) return true;
+  return /^[A-Za-z]:\//.test(path);
+}
+
+function isRelativeSpecifier(path: string): boolean {
+  return path.startsWith("./") || path.startsWith("../");
+}
+
+function ensureRelativeSpecifier(path: string): string {
+  if (isRelativeSpecifier(path)) return path;
+  return `./${path}`;
+}
+
+function buildDefinitionSource(modulePath: string, typeName: string): string {
+  return [
+    `import type * as ${ROOT_MODULE_ALIAS} from ${JSON.stringify(modulePath)};`,
+    `type ${ROOT_TYPE_ALIAS} = ${ROOT_MODULE_ALIAS}.${typeName};`,
+    "",
+    `declare const value: ${ROOT_TYPE_ALIAS};`,
+    "void value;",
+    "",
+  ].join("\n");
+}
+
+function toPosixPath(path: string): string {
+  return path.replaceAll("\\", "/");
+}
+
+function resolveCompilerOptions(options: CheckOptions): ts.CompilerOptions {
+  const defaults: ts.CompilerOptions = {
+    noEmit: true,
+    moduleResolution: ts.ModuleResolutionKind.NodeNext,
+    module: ts.ModuleKind.NodeNext,
+    target: ts.ScriptTarget.ESNext,
+    allowImportingTsExtensions: true,
+  };
+
+  if (options.compilerOptions) {
+    return {
+      ...defaults,
+      ...options.compilerOptions,
+      noEmit: true,
+      allowImportingTsExtensions: true,
+    };
+  }
+
+  const tsconfigPath = findNearestTsconfigPath(
+    options.baseFilePath,
+    options.fs,
+  );
+  if (!tsconfigPath) return defaults;
+
+  const read = options.fs?.readFile ??
+    ((path: string) => ts.sys.readFile(path));
+  const configResult = ts.readConfigFile(tsconfigPath, read);
+  if (configResult.error) return defaults;
+
+  const configHost = options.fs
+    ? {
+      useCaseSensitiveFileNames: ts.sys.useCaseSensitiveFileNames,
+      readDirectory: ts.sys.readDirectory,
+      fileExists: options.fs.fileExists,
+      readFile: options.fs.readFile,
+    }
+    : ts.sys;
+
+  const parsed = ts.parseJsonConfigFileContent(
+    configResult.config,
+    configHost,
+    dirname(tsconfigPath),
+    undefined,
+    tsconfigPath,
+  );
+
+  if (parsed.errors.length > 0) return defaults;
+
+  return {
+    ...defaults,
+    ...parsed.options,
+    noEmit: true,
+    allowImportingTsExtensions: true,
+  };
+}
+
+function findNearestTsconfigPath(
+  baseFilePath?: string,
+  fs?: CheckOptions["fs"],
+): string | undefined {
+  const normalizedBasePath = baseFilePath && baseFilePath.length > 0
+    ? toPosixPath(baseFilePath)
+    : undefined;
+  const searchStart = normalizedBasePath
+    ? dirname(normalizedBasePath)
+    : Deno.cwd();
+
+  if (fs?.findConfigFile) {
+    return fs.findConfigFile(searchStart);
+  }
+
+  const exists = fs?.fileExists ?? ts.sys.fileExists;
+  return ts.findConfigFile(searchStart, exists, "tsconfig.json");
+}
+
+function resolvePropertyMatches(
+  checker: ts.TypeChecker,
+  type: ts.Type,
+  name: string,
+): Array<{ symbol: ts.Symbol; type: ts.Type }> {
+  const matches: Array<{ symbol: ts.Symbol; type: ts.Type }> = [];
+
+  for (const candidate of flattenTypes(type)) {
+    const apparent = checker.getApparentType(candidate);
+    const symbol = checker.getPropertyOfType(apparent, name);
+    if (!symbol) continue;
+
+    const anchor = symbol.valueDeclaration ?? symbol.declarations?.[0];
+    if (!anchor) continue;
+
+    matches.push({
+      symbol,
+      type: checker.getTypeOfSymbolAtLocation(symbol, anchor),
+    });
+  }
+
+  return matches;
+}
+
+function resolveIndexedTypes(
+  checker: ts.TypeChecker,
+  type: ts.Type,
+  index: number,
+): ts.Type[] {
+  const results: ts.Type[] = [];
+
+  for (const candidate of flattenTypes(type)) {
+    const apparent = checker.getApparentType(candidate);
+
+    if (checker.isTupleType(apparent)) {
+      const typeArguments = checker.getTypeArguments(
+        apparent as ts.TypeReference,
+      );
+      if (index < typeArguments.length) {
+        results.push(typeArguments[index]);
+        continue;
+      }
+    }
+
+    const indexed = checker.getIndexTypeOfType(apparent, ts.IndexKind.Number) ??
+      checker.getIndexTypeOfType(candidate, ts.IndexKind.Number);
+    if (indexed) {
+      results.push(indexed);
+    }
+  }
+
+  return results;
+}
+
+function flattenTypes(type: ts.Type): ts.Type[] {
+  if (type.isUnion()) {
+    return type.types.flatMap((item) => flattenTypes(item));
+  }
+  if (type.isIntersection()) {
+    return type.types.flatMap((item) => flattenTypes(item));
+  }
+  return [type];
+}
+
+function dedupeTypes(types: ts.Type[]): ts.Type[] {
+  return Array.from(new Set(types));
+}
+
+function dedupeSymbols(symbols: ts.Symbol[]): ts.Symbol[] {
+  const unique = new Map<string, ts.Symbol>();
+  for (const symbol of symbols) {
+    unique.set(symbolKey(symbol), symbol);
+  }
+  return Array.from(unique.values());
+}
+
+function symbolKey(symbol: ts.Symbol): string {
+  const declaration = symbol.valueDeclaration ?? symbol.declarations?.[0];
+  if (!declaration) return symbol.getName();
+  return `${declaration.getSourceFile().fileName}:${declaration.getStart()}:${symbol.getName()}`;
+}
+
+function symbolsToDefinition(
+  symbols: readonly ts.Symbol[],
+): TypeDefinition | null {
+  for (const symbol of symbols) {
+    const definition = symbolToDefinition(symbol);
+    if (definition) return definition;
+  }
+  return null;
+}
+
+function symbolToDefinition(symbol: ts.Symbol): TypeDefinition | null {
+  const declaration = symbol.valueDeclaration ?? symbol.declarations?.[0];
+  if (!declaration) return null;
+
+  const selectionNode = getSelectionNode(declaration);
+  return {
+    filePath: declaration.getSourceFile().fileName,
+    targetSpan: nodeToSpan(declaration),
+    targetSelectionSpan: nodeToSpan(selectionNode ?? declaration),
+  };
+}
+
+function getSelectionNode(declaration: ts.Declaration): ts.Node | undefined {
+  if ("name" in declaration) {
+    const named = declaration as ts.NamedDeclaration;
+    if (named.name) return named.name;
+  }
+  return undefined;
+}
+
+function nodeToSpan(node: ts.Node): Span {
+  const sourceFile = node.getSourceFile();
+  return {
+    start: node.getStart(sourceFile),
+    end: node.getEnd(),
+  };
+}
+
+function findRootTypeDefinition(
+  sourceFile: ts.SourceFile,
+  checker: ts.TypeChecker,
+): TypeDefinition | null {
+  const aliasDeclaration = findTypeAliasDeclarationInFile(
+    sourceFile,
+    ROOT_TYPE_ALIAS,
+  );
+  if (!aliasDeclaration || !ts.isTypeReferenceNode(aliasDeclaration.type)) {
+    return null;
+  }
+
+  const rootName = getRightmostEntityName(aliasDeclaration.type.typeName);
+  const symbol = checker.getSymbolAtLocation(rootName);
+  if (!symbol) return null;
+
+  return symbolToDefinition(symbol);
+}
+
+function findValueDeclarationInFile(
+  file: ts.SourceFile,
+): ts.VariableDeclaration | undefined {
+  let found: ts.VariableDeclaration | undefined;
+
+  const visit = (node: ts.Node): void => {
+    if (found) return;
+    if (isValueDeclaration(node)) {
+      found = node;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+
+  visit(file);
+  return found;
+}
+
+function isValueDeclaration(node: ts.Node): node is ts.VariableDeclaration {
+  return ts.isVariableDeclaration(node) &&
+    ts.isIdentifier(node.name) &&
+    node.name.text === "value" &&
+    node.type != null;
+}
+
+function findTypeAliasDeclarationInFile(
+  file: ts.SourceFile,
+  name: string,
+): ts.TypeAliasDeclaration | undefined {
+  let found: ts.TypeAliasDeclaration | undefined;
+
+  const visit = (node: ts.Node): void => {
+    if (found) return;
+    if (ts.isTypeAliasDeclaration(node) && node.name.text === name) {
+      found = node;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+
+  visit(file);
+  return found;
+}
+
+function getRightmostEntityName(name: ts.EntityName): ts.Identifier {
+  if (ts.isIdentifier(name)) return name;
+  return getRightmostEntityName(name.right);
+}

--- a/json-type-checker/src/definition.ts
+++ b/json-type-checker/src/definition.ts
@@ -79,7 +79,7 @@ export function findDefinition(
         ),
       );
       if (nextTypes.length === 0) {
-        return symbolsToDefinition(lastSymbols);
+        return null;
       }
       currentTypes = nextTypes;
       continue;
@@ -89,7 +89,7 @@ export function findDefinition(
       resolvePropertyMatches(checker, type, item)
     );
     if (matches.length === 0) {
-      return symbolsToDefinition(lastSymbols);
+      return null;
     }
 
     lastSymbols = dedupeSymbols(matches.map((item) => item.symbol));

--- a/json-type-checker/src/document.test.ts
+++ b/json-type-checker/src/document.test.ts
@@ -1,0 +1,62 @@
+import { assertEquals } from "@std/assert";
+import { parseDocumentContext } from "./document.ts";
+
+Deno.test("parseDocumentContext resolves json field paths from cursor offsets", () => {
+  const text = `{
+  "user": {
+    "aliases": [
+      {
+        "name": "Alice"
+      }
+    ]
+  }
+}`;
+  const context = parseDocumentContext("json", text);
+
+  assertEquals(context.offsetToPath(text.indexOf('"user"') + 1), ["user"]);
+  assertEquals(context.offsetToPath(text.indexOf('"aliases"') + 1), [
+    "user",
+    "aliases",
+  ]);
+  assertEquals(context.offsetToPath(text.indexOf('"name"') + 1), [
+    "user",
+    "aliases",
+    0,
+    "name",
+  ]);
+});
+
+Deno.test("parseDocumentContext resolves jsonc field paths from cursor offsets", () => {
+  const text = `{
+  // comment
+  "user": {
+    "name": "Alice"
+  }
+}`;
+  const context = parseDocumentContext("jsonc", text);
+
+  assertEquals(context.offsetToPath(text.indexOf('"name"') + 1), [
+    "user",
+    "name",
+  ]);
+});
+
+Deno.test("parseDocumentContext resolves yaml field paths from cursor offsets", () => {
+  const text = `user:
+  addresses:
+    - street: Main
+`;
+  const context = parseDocumentContext("yaml", text);
+
+  assertEquals(context.offsetToPath(text.indexOf("user")), ["user"]);
+  assertEquals(context.offsetToPath(text.indexOf("addresses")), [
+    "user",
+    "addresses",
+  ]);
+  assertEquals(context.offsetToPath(text.indexOf("street")), [
+    "user",
+    "addresses",
+    0,
+    "street",
+  ]);
+});

--- a/json-type-checker/src/document.ts
+++ b/json-type-checker/src/document.ts
@@ -1,14 +1,20 @@
-import { parseTree, type ParseErrorCode, printParseErrorCode } from "jsonc-parser";
+import {
+  type ParseErrorCode,
+  parseTree,
+  printParseErrorCode,
+} from "jsonc-parser";
 import ts from "typescript";
 import { parseDocument as parseYamlDocument } from "yaml";
 import { diagnosticToPath } from "./check.ts";
 import {
   jsonTextToRoughJson,
+  offsetToPath as jsonOffsetToPath,
   pathToSpan as jsonPathToSpan,
 } from "./json.ts";
 import type { RoughJson } from "./rough-json.ts";
 import type { Path, Span } from "./type.ts";
 import {
+  offsetToPath as yamlOffsetToPath,
   pathToSpan as yamlPathToSpan,
   yamlDocumentToRoughJson,
 } from "./yaml.ts";
@@ -22,6 +28,7 @@ export interface ParseDocumentOptions {
 export interface ParsedDocumentContext {
   roughJson: RoughJson;
   pathToSpan: (path: Path) => Span;
+  offsetToPath: (offset: number) => Path | null;
 }
 
 export interface DocumentDiagnostic {
@@ -32,8 +39,11 @@ export interface DocumentDiagnostic {
   span: Span | null;
 }
 
-export function isSupportedLanguage(languageId: string): languageId is SupportedLanguageId {
-  return languageId === "json" || languageId === "jsonc" || languageId === "yaml";
+export function isSupportedLanguage(
+  languageId: string,
+): languageId is SupportedLanguageId {
+  return languageId === "json" || languageId === "jsonc" ||
+    languageId === "yaml";
 }
 
 export function parseDocumentContext(
@@ -42,7 +52,8 @@ export function parseDocumentContext(
   options: ParseDocumentOptions = {},
 ): ParsedDocumentContext {
   if (languageId === "json" || languageId === "jsonc") {
-    const errors: { error: ParseErrorCode; offset: number; length: number }[] = [];
+    const errors: { error: ParseErrorCode; offset: number; length: number }[] =
+      [];
     const root = parseTree(text, errors);
     if (options.strict && errors.length > 0) {
       throw new Error(formatJsonParseErrors(errors));
@@ -54,6 +65,7 @@ export function parseDocumentContext(
       return {
         roughJson: { type: "null" },
         pathToSpan: () => ({ start: 0, end: 0 }),
+        offsetToPath: () => null,
       };
     }
 
@@ -61,6 +73,7 @@ export function parseDocumentContext(
     return {
       roughJson,
       pathToSpan: (path) => jsonPathToSpan(root, path),
+      offsetToPath: (offset) => jsonOffsetToPath(root, offset),
     };
   }
 
@@ -72,12 +85,15 @@ export function parseDocumentContext(
   return {
     roughJson,
     pathToSpan: (path) => yamlPathToSpan(yamlDocument, path),
+    offsetToPath: (offset) => yamlOffsetToPath(yamlDocument, offset),
   };
 }
 
 export function getTypePath(roughJson: RoughJson): string | null {
   if (roughJson.type !== "object") return null;
-  const typeField = roughJson.items.findLast((item) => item.key.value === "$type");
+  const typeField = roughJson.items.findLast((item) =>
+    item.key.value === "$type"
+  );
   if (!typeField || typeField.value.type !== "string") return null;
   return typeField.value.value;
 }

--- a/json-type-checker/src/json.ts
+++ b/json-type-checker/src/json.ts
@@ -16,6 +16,11 @@ export function pathToSpan(node: Node, path: Path): Span {
   return currentSpan;
 }
 
+export function offsetToPath(node: Node, offset: number): Path | null {
+  if (!containsOffset(node, offset)) return null;
+  return findPathAtOffset(node, offset, []);
+}
+
 export function jsonTextToRoughJson(jsonText: string): RoughJson {
   const node = parseTree(jsonText);
   if (!node) return { type: "null" };
@@ -97,6 +102,61 @@ function getChildNode(
   }
 }
 
+function findPathAtOffset(node: Node, offset: number, basePath: Path): Path {
+  switch (node.type) {
+    case "object": {
+      for (const property of node.children ?? []) {
+        if (property.type !== "property") continue;
+
+        const keyNode = property.children?.[0];
+        const valueNode = property.children?.[1];
+        const key = String(keyNode?.value ?? "");
+        const nextPath = [...basePath, key];
+
+        if (keyNode && containsOffset(keyNode, offset)) {
+          return nextPath;
+        }
+
+        if (valueNode && containsOffset(valueNode, offset)) {
+          return findPathAtOffset(valueNode, offset, nextPath);
+        }
+
+        if (containsOffset(property, offset)) {
+          return nextPath;
+        }
+      }
+
+      return basePath;
+    }
+    case "array": {
+      for (const [index, child] of (node.children ?? []).entries()) {
+        if (!containsOffset(child, offset)) continue;
+        return findPathAtOffset(child, offset, [...basePath, index]);
+      }
+
+      return basePath;
+    }
+    case "property": {
+      const keyNode = node.children?.[0];
+      const valueNode = node.children?.[1];
+      const key = String(keyNode?.value ?? "");
+      const nextPath = [...basePath, key];
+
+      if (keyNode && containsOffset(keyNode, offset)) {
+        return nextPath;
+      }
+
+      if (valueNode && containsOffset(valueNode, offset)) {
+        return findPathAtOffset(valueNode, offset, nextPath);
+      }
+
+      return nextPath;
+    }
+    default:
+      return basePath;
+  }
+}
+
 function getNodeSpan(node: Node): Span {
   return { start: node.offset, end: node.offset + node.length };
 }
@@ -107,4 +167,8 @@ function getNumberText(node: Node, jsonText?: string): string {
     if (raw.length > 0) return raw;
   }
   return String(node.value);
+}
+
+function containsOffset(node: Node, offset: number): boolean {
+  return offset >= node.offset && offset < node.offset + node.length;
 }

--- a/json-type-checker/src/yaml.ts
+++ b/json-type-checker/src/yaml.ts
@@ -24,6 +24,18 @@ export function pathToSpan(document: Document.Parsed, path: Path): Span {
   return currentSpan;
 }
 
+export function offsetToPath(
+  document: Document.Parsed,
+  offset: number,
+): Path | null {
+  const rootSpan = getYamlDocumentSpan(document);
+  if (rootSpan && !containsOffset(rootSpan, offset)) return null;
+
+  const root = document.contents;
+  if (!root) return [];
+  return findPathAtOffset(root, offset, []);
+}
+
 export function yamlTextToRoughJson(yamlText: string): RoughJson {
   const document = parseYamlDocument(yamlText, { keepSourceTokens: true });
   return nodeToRoughJson(document.contents);
@@ -173,6 +185,44 @@ function getChildNode(node: unknown, pathItem: string | number): unknown {
   return undefined;
 }
 
+function findPathAtOffset(node: unknown, offset: number, basePath: Path): Path {
+  if (isMap(node)) {
+    for (const pair of node.items) {
+      const key = keyToString(pair.key);
+      const nextPath = [...basePath, key];
+
+      const keySpan = getYamlNodeSpan(pair.key);
+      if (keySpan && containsOffset(keySpan, offset)) {
+        return nextPath;
+      }
+
+      const valueSpan = getYamlNodeSpan(pair.value);
+      if (valueSpan && containsOffset(valueSpan, offset)) {
+        return findPathAtOffset(pair.value, offset, nextPath);
+      }
+
+      const pairSpan = getYamlNodeSpan(pair) ?? getYamlNodeRangeSpan(pair);
+      if (pairSpan && containsOffset(pairSpan, offset)) {
+        return nextPath;
+      }
+    }
+
+    return basePath;
+  }
+
+  if (isSeq(node)) {
+    for (const [index, item] of node.items.entries()) {
+      const itemSpan = getYamlNodeSpan(item);
+      if (!itemSpan || !containsOffset(itemSpan, offset)) continue;
+      return findPathAtOffset(item, offset, [...basePath, index]);
+    }
+
+    return basePath;
+  }
+
+  return basePath;
+}
+
 function getYamlNodeSpan(node: unknown): Span | undefined {
   const sourceToken = getYamlSourceToken(node);
   if (sourceToken) {
@@ -216,4 +266,15 @@ function getYamlNodeRange(node: unknown): [number, number] | undefined {
   if (typeof start !== "number" || typeof end !== "number") return;
   if (end < start) return;
   return [start, end];
+}
+
+function getYamlNodeRangeSpan(node: unknown): Span | undefined {
+  const range = getYamlNodeRange(node);
+  if (!range) return;
+  const [start, end] = range;
+  return { start, end };
+}
+
+function containsOffset(span: Span, offset: number): boolean {
+  return offset >= span.start && offset < span.end;
 }

--- a/jtc-cli/src/lsp.ts
+++ b/jtc-cli/src/lsp.ts
@@ -9,7 +9,10 @@ import {
   TextDocumentSyncKind,
 } from "vscode-languageserver/node.js";
 import process from "node:process";
-import { check } from "../../json-type-checker/src/check.ts";
+import {
+  check,
+  type CheckFileSystem,
+} from "../../json-type-checker/src/check.ts";
 import { findDefinition } from "../../json-type-checker/src/definition.ts";
 import {
   getTypePath,
@@ -177,6 +180,7 @@ async function buildDefinitionLinks(
     if (!isSupportedLanguage(document.languageId)) return null;
     const filePath = uriToFilePath(document.uri);
     if (!filePath) return null;
+    const fs = createOpenDocumentOverlayFs(openDocuments);
 
     const context = parseDocumentContext(document.languageId, document.text);
     const typePath = getTypePath(context.roughJson);
@@ -186,12 +190,14 @@ async function buildDefinitionLinks(
     const path = context.offsetToPath(offset);
     if (!path || path.length === 0) return null;
 
-    const target = findDefinition(path, typePath, { baseFilePath: filePath });
+    const target = findDefinition(path, typePath, {
+      baseFilePath: filePath,
+      fs,
+    });
     if (!target) return null;
 
     const targetUri = toFileUrl(target.filePath).href;
-    const targetText = openDocuments.get(targetUri)?.text ??
-      await safeReadTextFile(target.filePath);
+    const targetText = fs.readFile(target.filePath);
     if (targetText == null) return null;
 
     return [{
@@ -319,10 +325,39 @@ function clamp(value: number, min: number, max: number): number {
   return Math.max(min, Math.min(max, value));
 }
 
-async function safeReadTextFile(filePath: string): Promise<string | null> {
-  try {
-    return await Deno.readTextFile(filePath);
-  } catch {
-    return null;
+function createOpenDocumentOverlayFs(
+  openDocuments: Map<string, OpenDocument>,
+): CheckFileSystem {
+  const openFileTexts = new Map<string, string>();
+
+  for (const document of openDocuments.values()) {
+    const filePath = uriToFilePath(document.uri);
+    if (!filePath) continue;
+    openFileTexts.set(pathKey(filePath), document.text);
   }
+
+  return {
+    fileExists(filePath: string): boolean {
+      if (openFileTexts.has(pathKey(filePath))) return true;
+      try {
+        return Deno.statSync(filePath).isFile;
+      } catch {
+        return false;
+      }
+    },
+    readFile(filePath: string): string | undefined {
+      const openText = openFileTexts.get(pathKey(filePath));
+      if (openText != null) return openText;
+      try {
+        return Deno.readTextFileSync(filePath);
+      } catch {
+        return undefined;
+      }
+    },
+  };
+}
+
+function pathKey(filePath: string): string {
+  const normalized = filePath.replaceAll("\\", "/");
+  return Deno.build.os === "windows" ? normalized.toLowerCase() : normalized;
 }

--- a/jtc-cli/src/lsp.ts
+++ b/jtc-cli/src/lsp.ts
@@ -1,14 +1,16 @@
-import { fromFileUrl } from "@std/path";
+import { fromFileUrl, toFileUrl } from "@std/path";
 import ts from "typescript";
 import {
   createConnection,
+  type DefinitionLink,
+  type Diagnostic,
   DiagnosticSeverity,
   ProposedFeatures,
   TextDocumentSyncKind,
-  type Diagnostic,
 } from "vscode-languageserver/node.js";
 import process from "node:process";
 import { check } from "../../json-type-checker/src/check.ts";
+import { findDefinition } from "../../json-type-checker/src/definition.ts";
 import {
   getTypePath,
   isSupportedLanguage,
@@ -39,6 +41,7 @@ export function runLsp(): void {
     return {
       capabilities: {
         textDocumentSync: TextDocumentSyncKind.Full,
+        definitionProvider: true,
       },
       serverInfo: {
         name: "jtc",
@@ -74,7 +77,21 @@ export function runLsp(): void {
 
   connection.onDidCloseTextDocument((event) => {
     openDocuments.delete(event.textDocument.uri);
-    connection.sendDiagnostics({ uri: event.textDocument.uri, diagnostics: [] });
+    connection.sendDiagnostics({
+      uri: event.textDocument.uri,
+      diagnostics: [],
+    });
+  });
+
+  connection.onDefinition(async (params) => {
+    const document = openDocuments.get(params.textDocument.uri);
+    if (!document) return null;
+    return await buildDefinitionLinks(
+      openDocuments,
+      document,
+      params.position.line,
+      params.position.character,
+    );
   });
 
   connection.onShutdown(() => {
@@ -118,8 +135,13 @@ async function buildDiagnostics(document: OpenDocument): Promise<Diagnostic[]> {
     if (!typePath) return [];
 
     const valueForCheck = omitTypeField(context.roughJson);
-    const tsDiagnostics = check(valueForCheck, typePath, { baseFilePath: filePath });
-    const mappedDiagnostics = mapDocumentDiagnostics(tsDiagnostics, context.pathToSpan);
+    const tsDiagnostics = check(valueForCheck, typePath, {
+      baseFilePath: filePath,
+    });
+    const mappedDiagnostics = mapDocumentDiagnostics(
+      tsDiagnostics,
+      context.pathToSpan,
+    );
 
     return mappedDiagnostics.map((item) => {
       return {
@@ -142,6 +164,51 @@ async function buildDiagnostics(document: OpenDocument): Promise<Diagnostic[]> {
         code: "jtc-internal",
       },
     ];
+  }
+}
+
+async function buildDefinitionLinks(
+  openDocuments: Map<string, OpenDocument>,
+  document: OpenDocument,
+  line: number,
+  character: number,
+): Promise<DefinitionLink[] | null> {
+  try {
+    if (!isSupportedLanguage(document.languageId)) return null;
+    const filePath = uriToFilePath(document.uri);
+    if (!filePath) return null;
+
+    const context = parseDocumentContext(document.languageId, document.text);
+    const typePath = getTypePath(context.roughJson);
+    if (!typePath) return null;
+
+    const offset = positionToOffset(document.text, line, character);
+    const path = context.offsetToPath(offset);
+    if (!path || path.length === 0) return null;
+
+    const target = findDefinition(path, typePath, { baseFilePath: filePath });
+    if (!target) return null;
+
+    const targetUri = toFileUrl(target.filePath).href;
+    const targetText = openDocuments.get(targetUri)?.text ??
+      await safeReadTextFile(target.filePath);
+    if (targetText == null) return null;
+
+    return [{
+      targetUri,
+      targetRange: spanToRange(
+        targetText,
+        target.targetSpan.start,
+        target.targetSpan.end,
+      ),
+      targetSelectionRange: spanToRange(
+        targetText,
+        target.targetSelectionSpan.start,
+        target.targetSelectionSpan.end,
+      ),
+    }];
+  } catch {
+    return null;
   }
 }
 
@@ -202,6 +269,31 @@ function spanToRange(
   };
 }
 
+function positionToOffset(
+  text: string,
+  line: number,
+  character: number,
+): number {
+  const safeLine = Math.max(0, line);
+  const safeCharacter = Math.max(0, character);
+  let currentLine = 0;
+  let index = 0;
+
+  while (index < text.length && currentLine < safeLine) {
+    if (text.charCodeAt(index) === 10) {
+      currentLine += 1;
+    }
+    index += 1;
+  }
+
+  let lineEnd = index;
+  while (lineEnd < text.length && text.charCodeAt(lineEnd) !== 10) {
+    lineEnd += 1;
+  }
+
+  return clamp(index + safeCharacter, index, lineEnd);
+}
+
 function offsetToPosition(
   text: string,
   offset: number,
@@ -225,4 +317,12 @@ function offsetToPosition(
 
 function clamp(value: number, min: number, max: number): number {
   return Math.max(min, Math.min(max, value));
+}
+
+async function safeReadTextFile(filePath: string): Promise<string | null> {
+  try {
+    return await Deno.readTextFile(filePath);
+  } catch {
+    return null;
+  }
 }

--- a/jtc-cli/test/lsp.test.ts
+++ b/jtc-cli/test/lsp.test.ts
@@ -108,6 +108,56 @@ Deno.test("jtc lsp resolves definitions for json fields", async () => {
   }
 });
 
+Deno.test("jtc lsp uses open TypeScript documents for definition spans", async () => {
+  const client = await startLspClient();
+  try {
+    const jsonPath = join(FIXTURES_DIR, "valid.json");
+    const jsonUri = toFileUrl(jsonPath).href;
+    const jsonText = await Deno.readTextFile(jsonPath);
+    const typesPath = join(FIXTURES_DIR, "types.ts");
+    const typesUri = toFileUrl(typesPath).href;
+    const typesText = `\n${await Deno.readTextFile(typesPath)}`;
+
+    client.connection.sendNotification(DidOpenTextDocumentNotification.type, {
+      textDocument: {
+        uri: typesUri,
+        languageId: "typescript",
+        version: 1,
+        text: typesText,
+      },
+    });
+
+    client.connection.sendNotification(DidOpenTextDocumentNotification.type, {
+      textDocument: {
+        uri: jsonUri,
+        languageId: "json",
+        version: 1,
+        text: jsonText,
+      },
+    });
+
+    const definition = await client.connection.sendRequest(
+      DefinitionRequest.type,
+      {
+        textDocument: { uri: jsonUri },
+        position: { line: 2, character: 3 },
+      },
+    );
+
+    assert(Array.isArray(definition));
+    assertEquals(definition.length, 1);
+    assert(isLocationLink(definition[0]));
+    if (!isLocationLink(definition[0])) {
+      throw new Error("expected LocationLink response");
+    }
+    assertEquals(definition[0].targetSelectionRange.start.line, 2);
+    assertEquals(definition[0].targetSelectionRange.start.character, 2);
+  } finally {
+    const code = await stopLspClient(client);
+    assertEquals(code, 0);
+  }
+});
+
 Deno.test("jtc lsp publishes diagnostics for invalid json document", async () => {
   const client = await startLspClient();
   try {

--- a/jtc-cli/test/lsp.test.ts
+++ b/jtc-cli/test/lsp.test.ts
@@ -4,10 +4,12 @@ import { spawn } from "node:child_process";
 import { once } from "node:events";
 import {
   createProtocolConnection,
+  DefinitionRequest,
   DidOpenTextDocumentNotification,
   ExitNotification,
   InitializedNotification,
   InitializeRequest,
+  type LocationLink,
   PublishDiagnosticsNotification,
   ShutdownRequest,
   StreamMessageReader,
@@ -24,6 +26,85 @@ Deno.test("jtc lsp handles initialize and shutdown handshake", async () => {
     assertEquals(code, 0);
   } finally {
     client.connection.dispose();
+  }
+});
+
+Deno.test("jtc lsp resolves definitions for json fields", async () => {
+  const client = await startLspClient();
+  try {
+    const filePath = join(FIXTURES_DIR, "valid.json");
+    const uri = toFileUrl(filePath).href;
+    const text = await Deno.readTextFile(filePath);
+
+    client.connection.sendNotification(DidOpenTextDocumentNotification.type, {
+      textDocument: {
+        uri,
+        languageId: "json",
+        version: 1,
+        text,
+      },
+    });
+
+    const fieldDefinition = await client.connection.sendRequest(
+      DefinitionRequest.type,
+      {
+        textDocument: { uri },
+        position: { line: 2, character: 3 },
+      },
+    );
+
+    assert(Array.isArray(fieldDefinition));
+    assertEquals(fieldDefinition.length, 1);
+    assert(isLocationLink(fieldDefinition[0]));
+    if (!isLocationLink(fieldDefinition[0])) {
+      throw new Error("expected LocationLink response");
+    }
+    assertEquals(
+      fieldDefinition[0].targetUri,
+      toFileUrl(join(FIXTURES_DIR, "types.ts")).href,
+    );
+    assertEquals(fieldDefinition[0].targetSelectionRange.start.line, 1);
+    assertEquals(fieldDefinition[0].targetSelectionRange.start.character, 2);
+
+    const typeKeyDefinition = await client.connection.sendRequest(
+      DefinitionRequest.type,
+      {
+        textDocument: { uri },
+        position: { line: 1, character: 3 },
+      },
+    );
+
+    assert(Array.isArray(typeKeyDefinition));
+    assertEquals(typeKeyDefinition.length, 1);
+    assert(isLocationLink(typeKeyDefinition[0]));
+    if (!isLocationLink(typeKeyDefinition[0])) {
+      throw new Error("expected LocationLink response");
+    }
+    assertEquals(typeKeyDefinition[0].targetSelectionRange.start.line, 0);
+    assertEquals(typeKeyDefinition[0].targetSelectionRange.start.character, 17);
+
+    const typeValueDefinition = await client.connection.sendRequest(
+      DefinitionRequest.type,
+      {
+        textDocument: { uri },
+        position: { line: 1, character: 14 },
+      },
+    );
+
+    assert(Array.isArray(typeValueDefinition));
+    assertEquals(typeValueDefinition.length, 1);
+    assert(isLocationLink(typeValueDefinition[0]));
+    if (!isLocationLink(typeValueDefinition[0])) {
+      throw new Error("expected LocationLink response");
+    }
+    assertEquals(typeValueDefinition[0].targetSelectionRange.start.line, 0);
+    assertEquals(
+      typeValueDefinition[0].targetSelectionRange.start.character,
+      17,
+    );
+  } finally {
+    const code = await stopLspClient(client);
+    assertEquals(code, 0);
   }
 });
 
@@ -92,7 +173,10 @@ async function startLspClient(): Promise<{
 }
 
 async function stopLspClient(
-  client: { child: ReturnType<typeof spawn>; connection: ReturnType<typeof createProtocolConnection> },
+  client: {
+    child: ReturnType<typeof spawn>;
+    connection: ReturnType<typeof createProtocolConnection>;
+  },
 ): Promise<number> {
   try {
     await client.connection.sendRequest(ShutdownRequest.type);
@@ -101,7 +185,10 @@ async function stopLspClient(
   }
   client.connection.sendNotification(ExitNotification.type);
   client.connection.dispose();
-  const [code] = await once(client.child, "exit") as [number | null, NodeJS.Signals | null];
+  const [code] = await once(client.child, "exit") as [
+    number | null,
+    NodeJS.Signals | null,
+  ];
   return code ?? 1;
 }
 
@@ -120,4 +207,9 @@ function waitForDiagnostics(
       resolve(params);
     });
   });
+}
+
+function isLocationLink(value: unknown): value is LocationLink {
+  if (!value || typeof value !== "object") return false;
+  return "targetUri" in value && "targetSelectionRange" in value;
 }

--- a/jtc-vscode/src/main.ts
+++ b/jtc-vscode/src/main.ts
@@ -91,7 +91,7 @@ async function buildDiagnostics(
       baseFilePath: checkOptions.baseFilePath,
       fs: checkOptions.fs,
       compilerOptions: checkOptions.compilerOptions,
-      preferFileSystemOnly: true,
+      preferFileSystemOnly: checkOptions.preferFileSystemOnly,
     });
 
     return mapDocumentDiagnostics(tsDiagnostics, context.pathToSpan).map((
@@ -108,6 +108,7 @@ type CheckRunOptions = {
   fs?: CheckFileSystem;
   compilerOptions?: ts.CompilerOptions;
   pathToUri?: Map<string, vscode.Uri>;
+  preferFileSystemOnly?: boolean;
 };
 
 async function buildDefinitionLinks(
@@ -131,7 +132,7 @@ async function buildDefinitionLinks(
       baseFilePath: checkOptions.baseFilePath,
       fs: checkOptions.fs,
       compilerOptions: checkOptions.compilerOptions,
-      preferFileSystemOnly: true,
+      preferFileSystemOnly: checkOptions.preferFileSystemOnly,
     });
     if (!target) return [];
 
@@ -159,9 +160,13 @@ async function createCheckOptions(
   typePath: string,
 ): Promise<CheckRunOptions> {
   if (document.uri.scheme === "file") {
+    const compilerOptions = await loadCompilerOptionsFromTsconfig(document.uri);
     return {
       typePath,
       baseFilePath: document.uri.fsPath,
+      fs: createOpenDocumentOverlayFs(),
+      compilerOptions,
+      preferFileSystemOnly: false,
     };
   }
 
@@ -185,6 +190,7 @@ async function createCheckOptions(
     fs,
     compilerOptions,
     pathToUri,
+    preferFileSystemOnly: true,
   };
 }
 
@@ -327,6 +333,24 @@ function createInMemoryFs(files: Map<string, string>): CheckFileSystem {
         if (parent === current) break;
         current = parent;
       }
+    },
+  };
+}
+
+function createOpenDocumentOverlayFs(): CheckFileSystem {
+  const openFiles = new Map<string, string>();
+
+  for (const document of vscode.workspace.textDocuments) {
+    if (document.uri.scheme !== "file") continue;
+    openFiles.set(normalizeFsPath(document.uri.fsPath), document.getText());
+  }
+
+  return {
+    fileExists(path: string): boolean {
+      return openFiles.has(normalizeFsPath(path));
+    },
+    readFile(path: string): string | undefined {
+      return openFiles.get(normalizeFsPath(path));
     },
   };
 }

--- a/jtc-vscode/src/main.ts
+++ b/jtc-vscode/src/main.ts
@@ -1,17 +1,15 @@
 import { dirname, extname, join, normalize } from "@std/path/posix";
 import ts from "typescript";
 import * as vscode from "vscode";
+import { check, type CheckFileSystem } from "@disjukr/jtc/check";
+import { findDefinition } from "@disjukr/jtc/definition";
 import {
-  check,
-  type CheckFileSystem,
-} from "@disjukr/jtc/check";
-import {
+  type DocumentDiagnostic,
   getTypePath,
   isSupportedLanguage,
   mapDocumentDiagnostics,
   omitTypeField,
   parseDocumentContext,
-  type DocumentDiagnostic,
 } from "@disjukr/jtc/document";
 import type { Span } from "@disjukr/jtc/type";
 
@@ -21,6 +19,20 @@ const TS_EXTENSIONS = [".ts", ".tsx", ".d.ts", ".mts", ".cts"];
 export function activate(context: vscode.ExtensionContext): void {
   const collection = vscode.languages.createDiagnosticCollection("jtc");
   context.subscriptions.push(collection);
+  context.subscriptions.push(
+    vscode.languages.registerDefinitionProvider(
+      [
+        { language: "json" },
+        { language: "jsonc" },
+        { language: "yaml" },
+      ],
+      {
+        provideDefinition(document, position) {
+          return buildDefinitionLinks(document, position);
+        },
+      },
+    ),
+  );
 
   const refresh = async (document: vscode.TextDocument): Promise<void> => {
     if (!isSupportedLanguage(document.languageId)) {
@@ -65,7 +77,10 @@ async function buildDiagnostics(
 ): Promise<vscode.Diagnostic[]> {
   try {
     if (!isSupportedLanguage(document.languageId)) return [];
-    const context = parseDocumentContext(document.languageId, document.getText());
+    const context = parseDocumentContext(
+      document.languageId,
+      document.getText(),
+    );
 
     const typePath = getTypePath(context.roughJson);
     if (!typePath) return [];
@@ -79,9 +94,9 @@ async function buildDiagnostics(
       preferFileSystemOnly: true,
     });
 
-    return mapDocumentDiagnostics(tsDiagnostics, context.pathToSpan).map((diagnostic) =>
-      toVsCodeDiagnostic(diagnostic, document)
-    );
+    return mapDocumentDiagnostics(tsDiagnostics, context.pathToSpan).map((
+      diagnostic,
+    ) => toVsCodeDiagnostic(diagnostic, document));
   } catch (err) {
     return [toInternalErrorDiagnostic(document, err)];
   }
@@ -92,7 +107,52 @@ type CheckRunOptions = {
   baseFilePath: string;
   fs?: CheckFileSystem;
   compilerOptions?: ts.CompilerOptions;
+  pathToUri?: Map<string, vscode.Uri>;
 };
+
+async function buildDefinitionLinks(
+  document: vscode.TextDocument,
+  position: vscode.Position,
+): Promise<vscode.LocationLink[]> {
+  try {
+    if (!isSupportedLanguage(document.languageId)) return [];
+    const context = parseDocumentContext(
+      document.languageId,
+      document.getText(),
+    );
+    const typePath = getTypePath(context.roughJson);
+    if (!typePath) return [];
+
+    const path = context.offsetToPath(document.offsetAt(position));
+    if (!path || path.length === 0) return [];
+
+    const checkOptions = await createCheckOptions(document, typePath);
+    const target = findDefinition(path, checkOptions.typePath, {
+      baseFilePath: checkOptions.baseFilePath,
+      fs: checkOptions.fs,
+      compilerOptions: checkOptions.compilerOptions,
+      preferFileSystemOnly: true,
+    });
+    if (!target) return [];
+
+    const targetUri = targetPathToUri(target.filePath, checkOptions.pathToUri);
+    if (!targetUri) return [];
+
+    const targetDocument = await openTextDocument(targetUri);
+    if (!targetDocument) return [];
+
+    return [{
+      targetUri,
+      targetRange: spanToRange(targetDocument, target.targetSpan),
+      targetSelectionRange: spanToRange(
+        targetDocument,
+        target.targetSelectionSpan,
+      ),
+    }];
+  } catch {
+    return [];
+  }
+}
 
 async function createCheckOptions(
   document: vscode.TextDocument,
@@ -111,24 +171,28 @@ async function createCheckOptions(
     throw new Error(`Cannot resolve module in $type: ${parsed.modulePath}`);
   }
 
-  const allFiles = await collectTypeScriptFiles(moduleUri);
+  const collected = await collectTypeScriptFiles(moduleUri);
   const baseFilePath = uriToVirtualPath(document.uri);
-  const fs = createInMemoryFs(allFiles);
+  const fs = createInMemoryFs(collected.files);
   const typePathForCheck = `${uriToVirtualPath(moduleUri)}#${parsed.typeName}`;
   const compilerOptions = await loadCompilerOptionsFromTsconfig(document.uri);
+  const pathToUri = new Map(collected.pathToUri);
+  pathToUri.set(baseFilePath, document.uri);
 
   return {
     typePath: typePathForCheck,
     baseFilePath,
     fs,
     compilerOptions,
+    pathToUri,
   };
 }
 
 async function collectTypeScriptFiles(
   entryUri: vscode.Uri,
-): Promise<Map<string, string>> {
-  const map = new Map<string, string>();
+): Promise<{ files: Map<string, string>; pathToUri: Map<string, vscode.Uri> }> {
+  const files = new Map<string, string>();
+  const pathToUri = new Map<string, vscode.Uri>();
   const queue: vscode.Uri[] = [entryUri];
   const seen = new Set<string>();
 
@@ -143,7 +207,9 @@ async function collectTypeScriptFiles(
     const text = await readTextFile(current);
     if (text == null) continue;
 
-    map.set(uriToVirtualPath(current), text);
+    const virtualPath = uriToVirtualPath(current);
+    files.set(virtualPath, text);
+    pathToUri.set(virtualPath, current);
 
     const references = collectReferencedSpecifiers(text);
     for (const specifier of references) {
@@ -154,7 +220,7 @@ async function collectTypeScriptFiles(
     }
   }
 
-  return map;
+  return { files, pathToUri };
 }
 
 function collectReferencedSpecifiers(text: string): string[] {
@@ -237,12 +303,13 @@ function createInMemoryFs(files: Map<string, string>): CheckFileSystem {
 
   const read = (path: string): string | undefined => {
     const normalized = normalizeFsPath(path);
-    return normalizedMap.get(normalized) ?? insensitiveMap.get(normalized.toLowerCase());
+    return normalizedMap.get(normalized) ??
+      insensitiveMap.get(normalized.toLowerCase());
   };
 
   const exists = (path: string): boolean => {
     return read(path) != null;
-  }
+  };
 
   return {
     fileExists(path: string): boolean {
@@ -352,6 +419,29 @@ function normalizeFsPath(path: string): string {
 
 function hasUriScheme(text: string): boolean {
   return /^[A-Za-z][A-Za-z0-9+.-]*:/.test(text);
+}
+
+async function openTextDocument(
+  uri: vscode.Uri,
+): Promise<vscode.TextDocument | undefined> {
+  const existing = vscode.workspace.textDocuments.find((item) =>
+    item.uri.toString() === uri.toString()
+  );
+  if (existing) return existing;
+
+  try {
+    return await vscode.workspace.openTextDocument(uri);
+  } catch {
+    return undefined;
+  }
+}
+
+function targetPathToUri(
+  filePath: string,
+  pathToUri?: Map<string, vscode.Uri>,
+): vscode.Uri | undefined {
+  const normalized = normalizeFsPath(filePath);
+  return pathToUri?.get(normalized) ?? vscode.Uri.file(filePath);
 }
 
 function toVsCodeDiagnostic(


### PR DESCRIPTION
## Summary
- add shared definition resolution from JSON/YAML field paths to TypeScript members
- wire go-to-definition into both the CLI LSP server and the VS Code extension
- resolve the \$type\ field itself to the root type declaration and cover it with tests

## Testing
- deno test --allow-env --allow-read --allow-write json-type-checker/src
- deno task test
- deno task build

Closes #3